### PR TITLE
update to v0.3.0 with several new features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Yao-Yuan Mao
+Copyright (c) 2015-2019 Yao-Yuan Mao
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 Tried of copying and pasting bibtex entries?
 Here's a new way to manage your bibtex entries --- do not manage them!
 
-`adstex` automatically identifies all citation keys in your TeX source files
-and use NASA's [Astrophysics Data System](https://ui.adsabs.harvard.edu/) (ADS)
+`adstex` automatically identifies all citation keys (e.g., identifiers, author+year)
+in your TeX source files and use
+NASA's [Astrophysics Data System](https://ui.adsabs.harvard.edu/) (ADS)
 to generate corresponding bibtex entries!
 
 
@@ -71,25 +72,34 @@ _Yes, simple as that._
 ## Usage
 
 Once you finish the paper (_sorry, can't help with that!_), simply run `adstex`
-with the following command:
+with the following command (_Internet connection is needed for `adstex` to work._):
 
 ```bash
-adstex input_file1.tex [input_file2.tex [...]] -o output_references.bib
+adstex your_tex_source.tex
 ```
 
-- You can provide multiple TeX source files (`input_file1.tex` ...) at once.
-Internet connection is needed for `adstex` to work.
+`adstex` will automatically build the bibtex files, and write to the bibtex
+source that you specified in your tex source file.
+
+- If you want to have more control on the output file, use the `-o` option:
+  ```bash
+  adstex your_tex_source.tex -o your_bib_source.bib
+  ```
+  Once `adstex` is done, it will write all bibtex entries in the file
+  that you specified with the `-o` option.
+
+- You can also provide multiple TeX source files at once:
+  ```bash
+  adstex your_tex_source1.tex [your_tex_source2.tex [...]] -o your_bib_source.bib
+  ```
 
 - For citation keys that are arXiv IDs, ADS bibcodes, or DOIs,
-`adstex` will automatically find the cooresponding bibtex entries.
+  `adstex` will automatically find the cooresponding bibtex entries.
 
 - For first author + year citation keys, `adstex` will search on NASA ADS and
-provide you a list of candidate papers to select from.
-If you don't see the paper you are looking for, you can
-directly enter an ADS bibcode or arXiv ID when prompted.
-
-- Once `adstex` is done, it will write all bibtex entries in the file
-that you specified with the `-o` option.
+  provide you a list of candidate papers to select from.
+  If you don't see the paper you are looking for, you can
+  directly enter an ADS bibcode or arXiv ID when prompted.
 
 - You can also find a complete option list by running:
   ```bash

--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ that you specified with the `-o` option.
     So `adstex` simply generates the bibtex file using the ADS on the fly.
 
     If you are already using a reference manager, you may want to continue to use it to generate bibtex files. You can then use `adstex` to fetch just the new entries (see FAQ #2).
-    You can also use `adstex` to update all existing entries with the latest version from the ADS
-    by specifying the option `--force-update`.
+    You can also use `adstex` to update all existing entries with the latest version from the ADS by running:
+    ```bash
+    adstex your_bibtex_file.bib
+    ```
 
 4. **Does this work with the ADS astronomy database only?**
 

--- a/adstex.py
+++ b/adstex.py
@@ -20,6 +20,8 @@ except ImportError:
     from urllib import unquote
 from collections import defaultdict
 from builtins import input
+from distutils.version import StrictVersion
+import requests
 import ads
 import bibtexparser
 
@@ -337,6 +339,19 @@ def main():
             fp.write(bib_dump_str)
 
     print(_headerize('Done!'))
+
+    # check version
+    try:
+        latest_version = StrictVersion(requests.get(
+            'https://pypi.python.org/pypi/adstex/json').json()['info']['version'])
+    except (requests.RequestException, KeyError, ValueError):
+        pass
+    else:
+        if latest_version > StrictVersion(__version__):
+            msg = 'A newer version of adstex (v{}) is now available!\n'.format(latest_version)
+            msg += 'Please consider updating it by running:\n\n'
+            msg += 'pip install adstex=={}'.format(latest_version)
+            print(_headerize(msg))
 
 
 if __name__ == "__main__":

--- a/adstex.py
+++ b/adstex.py
@@ -1,6 +1,6 @@
 """
-Find all citation keys in your LaTeX documents and search NASA ADS
-to generate corresponding bibtex entries.
+adstex: Automated generation of NASA ADS bibtex entries
+from citation keys (identifiers, author+year) in your TeX source files.
 
 Project website: https://github.com/yymao/adstex
 

--- a/adstex.py
+++ b/adstex.py
@@ -27,6 +27,7 @@ __version__ = "0.2.3"
 _this_year = date.today().year % 100
 _this_cent = date.today().year // 100
 
+_re_comment = re.compile(r'(?<!\\)%.*(?=\v)')
 _re_cite = re.compile(r'\\[cC]ite[a-z]{0,7}\*?(?:\[.*?\])*{([\w\s/&.:,-]+)}')
 _re_fayear = re.compile(r'([A-Za-z-]+)(?:(?=[\W_])[^\s\d,]+)?((?:\d{2})?\d{2})')
 _re_id = {}
@@ -89,6 +90,7 @@ def search_keys(files):
     for f in files:
         with open(f) as fp:
             text = fp.read()
+        text = _re_comment.sub('', text)
         for m in _re_cite.finditer(text):
             for k in m.groups()[0].split(','):
                 keys.add(k.strip())

--- a/adstex.py
+++ b/adstex.py
@@ -100,8 +100,14 @@ def search_keys(files, find_bib=False):
         text = _re_comment.sub('', text)
         if find_bib and not bib:
             m = _re_bib.search(text)
-            bib = [b.strip() + ('' if b.endswith('.bib') else '.bib') \
-                for b in m.groups()[0].split(',')] if m else None
+            if m:
+                dirpath = os.path.dirname(f)
+                bib = []
+                for b in m.groups()[0].split(','):
+                    b = b.strip()
+                    if not b.lower().endswith('.bib'):
+                        b += '.bib'
+                    bib.append(os.path.join(dirpath, b))
         for m in _re_cite.finditer(text):
             for k in m.groups()[0].split(','):
                 keys.add(k.strip())

--- a/adstex.py
+++ b/adstex.py
@@ -5,7 +5,7 @@ to generate corresponding bibtex entries.
 Project website: https://github.com/yymao/adstex
 
 The MIT License (MIT)
-Copyright (c) 2015-2018 Yao-Yuan Mao (yymao)
+Copyright (c) 2015-2019 Yao-Yuan Mao (yymao)
 http://opensource.org/licenses/MIT
 """
 from __future__ import print_function

--- a/adstex.py
+++ b/adstex.py
@@ -295,33 +295,33 @@ def main():
     not_found = set()
     to_retrieve = set()
     all_entries = defaultdict(list)
-    try:
-        for key in keys:
-            if key in bib.entries_dict:
-                if args.update:
-                    bibcode = extract_bibcode(bib.entries_dict[key])
-                    bibcode_new = entry2bibcode(bib.entries_dict[key])
-                    if bibcode_new:
-                        all_entries[bibcode_new].append(key)
-                        if bibcode_new != bibcode or args.force_regenerate:
-                            to_retrieve.add(bibcode_new)
-                            print('{}: UPDATE => {}'.format(key, bibcode_new))
-                            continue
-                print('{}: EXISTING'.format(key))
-                continue
 
-            if key in bib_other.entries_dict:
-                print('{}: FOUND IN OTHER BIB SOURCE, IGNORED'.format(key))
-                continue
+    for key in keys:
+        if key in bib.entries_dict:
+            if args.update:
+                bibcode = extract_bibcode(bib.entries_dict[key])
+                bibcode_new = entry2bibcode(bib.entries_dict[key])
+                if bibcode_new:
+                    all_entries[bibcode_new].append(key)
+                    if bibcode_new != bibcode or args.force_regenerate:
+                        to_retrieve.add(bibcode_new)
+                        print('{}: UPDATE => {}'.format(key, bibcode_new))
+                        continue
+            print('{}: EXISTING'.format(key))
+            continue
 
-            bibcode = find_bibcode(key)
-            if bibcode:
-                to_retrieve.add(bibcode)
-                all_entries[bibcode].append(key)
-                print('{}: NEW ENTRY => {}'.format(key, bibcode))
-            else:
-                not_found.add(key)
-                print('{}: NOT FOUND'.format(key))
+        if key in bib_other.entries_dict:
+            print('{}: FOUND IN OTHER BIB SOURCE, IGNORED'.format(key))
+            continue
+
+        bibcode = find_bibcode(key)
+        if bibcode:
+            to_retrieve.add(bibcode)
+            all_entries[bibcode].append(key)
+            print('{}: NEW ENTRY => {}'.format(key, bibcode))
+        else:
+            not_found.add(key)
+            print('{}: NOT FOUND'.format(key))
     except KeyboardInterrupt:
         print()
 
@@ -365,4 +365,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print(_headerize("Abort! adstex interupted by a keyboard signal!"))

--- a/adstex.py
+++ b/adstex.py
@@ -25,7 +25,7 @@ import requests
 import ads
 import bibtexparser
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 
 _this_year = date.today().year % 100
 _this_cent = date.today().year // 100
@@ -322,8 +322,6 @@ def main():
         else:
             not_found.add(key)
             print('{}: NOT FOUND'.format(key))
-    except KeyboardInterrupt:
-        print()
 
     if not_found:
         print(_headerize('Please check the following keys'))

--- a/adstex.py
+++ b/adstex.py
@@ -259,6 +259,12 @@ def main():
         else:
             args.other = bib
 
+        msg = 'Auto-identifying bibtex files...\n'
+        msg += 'Main bibtex source (output file): {}\n'.format(args.output)
+        if args.other:
+            msg += 'Additional bibtex sources: {}\n'.format(', '.join(args.other))
+        print(_headerize(msg))
+
     if os.path.isfile(args.output):
         with open(args.output) as fp:
             bib = bibtexparser.load(fp, parser=get_bparser())

--- a/adstex.py
+++ b/adstex.py
@@ -244,9 +244,11 @@ def main():
 
     if len(args.files) == 1 and args.files[0].lower().endswith('.bib'): # bib update mode
         if args.output or args.other:
-            raise parser.error('Input file is a bib file, not tex file. This will enter bib update mode. Do not specify "output" and "other".')
+            parser.error('Input file is a bib file, not tex file. This will enter bib update mode. Do not specify "output" and "other".')
         if not args.update:
-            raise parser.error('Input file is a bib file, not tex file. This will enter bib update mode. Must not specify --no-update')
+            parser.error('Input file is a bib file, not tex file. This will enter bib update mode. Must not specify --no-update')
+        if not os.path.isfile(args.files[0]):
+            parser.error('Cannot locate input bib file {}'.format(args.files[0]))
         keys = None
         args.output = args.files[0]
 
@@ -255,6 +257,8 @@ def main():
 
     else: # bib output is missing, auto-identify
         keys, bib = search_keys(args.files, find_bib=True)
+        if not bib:
+            parser.error('Cannot identify bibtex file from the tex source. Use -o to specify a bibtex file as output.')
         args.output = bib.pop(0)
         if args.other:
             args.other.extend(bib)

--- a/adstex.py
+++ b/adstex.py
@@ -22,7 +22,7 @@ from builtins import input
 import ads
 import bibtexparser
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 _this_year = date.today().year % 100
 _this_cent = date.today().year // 100

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ to generate corresponding bibtex entries.
 Project website: https://github.com/yymao/adstex
 
 The MIT License (MIT)
-Copyright (c) 2015-2018 Yao-Yuan Mao (yymao)
+Copyright (c) 2015-2019 Yao-Yuan Mao (yymao)
 http://opensource.org/licenses/MIT
 """
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-Find all citation keys in your LaTeX documents and search NASA ADS
-to generate corresponding bibtex entries.
+adstex: Automated generation of NASA ADS bibtex entries
+from citation keys (identifiers, author+year) in your TeX source files.
 
 Project website: https://github.com/yymao/adstex
 
@@ -45,7 +45,7 @@ setup(
     ],
     keywords='bibtex ads',
     py_modules=[_name],
-    install_requires=['future','ads>=0.12.3','bibtexparser>=0.6.2'],
+    install_requires=['future', 'ads>=0.12.3', 'bibtexparser>=0.6.2'],
     entry_points={
         'console_scripts': [
             'adstex=adstex:main',


### PR DESCRIPTION
This PR implements the following new features:
- `adstex` can now just update a bibtex file (i.e., no tex source files needed) (fix #3)
- `adstex` now ignores (almost all) comments (fix #4)
- `adstex` will now automatically identify the bibtex files used by scanning the tex source file  when `-o` is not specified (fix #5)
- `adstex` will now back up the bib file that it will overwrite
- `adstex` will now check if a newer version of `adstex` is available on pypi
- `adstex` option `--force-update` is renamed to `--force-regenerate` for clarity. 

Thanks to @JohannesBuchner and @slosar for their suggestions. 