### PR TITLE
Add option to disable ssl verify

### DIFF
--- a/adstex.py
+++ b/adstex.py
@@ -344,7 +344,7 @@ def main():
         if ans in ("y", "Y", "yes", "Yes", "YES"):
             global _disable_ssl_verification
             _disable_ssl_verification = True
-            warnings.filterwarnings("ignore", "Unverified HTTPS request is being made to host", Warning)
+            warnings.filterwarnings("ignore", "Unverified HTTPS request is being made", Warning)
         else:
             print("OK, abort!")
             return


### PR DESCRIPTION
This PR adds an option `--disable-ssl-verification` to temporarily disable SSL verification. This can come in handy when the NASA ADS site updates its certificates. This should fix #33. 