### PR TITLE
make lower case -p acceptable 

### DIFF
--- a/adstex.py
+++ b/adstex.py
@@ -334,6 +334,7 @@ def main():
     parser.add_argument(
         "--parallel",
         "-P",
+        "-p",
         action="store_true",
         help="enable parallel ADS update queries",
     )  # thanks to dwijn for adding this option


### PR DESCRIPTION
this PR makes `-p` also an alternative option to `--parallel` (in addition to `-P`)