### PR TITLE
bugfix for merge-other

### DIFF
--- a/adstex.py
+++ b/adstex.py
@@ -519,6 +519,8 @@ def main():
             copyfile(args.output, args.output + ".bak")
         with open(args.output, "wb") as fp:
             fp.write(bib_dump_str)
+    else:
+        print('Nothing to write/update.')
 
     print(_headerize("Done!"))
 

--- a/adstex.py
+++ b/adstex.py
@@ -454,8 +454,8 @@ def main():
             return
 
         if key_exists_in_others and args.merge_other:
-            bib.entries_dict[key] = bib_other.entries_dict[key]
-            bib.entries = list(bib.entries_dict.values())
+            bib._entries_dict[key] = bib_other.entries_dict[key]
+            bib.entries = list(bib._entries_dict.values())
             print("{}: FOUND IN OTHER BIB SOURCE, MERGED".format(key))
             return
 

--- a/adstex.py
+++ b/adstex.py
@@ -454,8 +454,7 @@ def main():
             return
 
         if key_exists_in_others and args.merge_other:
-            bib._entries_dict[key] = bib_other.entries_dict[key]
-            bib.entries = list(bib._entries_dict.values())
+            bib.entries.append(bib_other.entries_dict[key])
             print("{}: FOUND IN OTHER BIB SOURCE, MERGED".format(key))
             return
 

--- a/adstex.py
+++ b/adstex.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     from urllib import unquote
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 _this_year = date.today().year % 100
 _this_cent = date.today().year // 100


### PR DESCRIPTION
Solved https://github.com/yymao/adstex/issues/44
Editing the property `bib.entries_dict` doesn't work. Use the underlying `bib._entries_dict` instead!

This wired bug is found by inserting the debugging code: 
```
            print("DEBUG:", key in bib.entries_dict, key in [_['ID'] for _ in bib.entries])
            print("{}: FOUND IN OTHER BIB SOURCE, MERGED".format(key))
```
I realized that editing the property `bib.entries_dict` will not change `bib._entries_dict`.
