### PR TITLE
v0.6.0: coauthor and default option features

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ to generate corresponding bibtex entries!
   and works with various styles of citation keys.
   For example, `adstex` would work with all the following:
   ```tex
-  \citet{1705.03888}
-  \citep[e.g.,][]{Mao:2015, White2018}
-  \citealt{10.1093/mnras/stx3111, 2017arXiv170909665M}
+  \citet{2404.14498}
+  \citep[e.g.,][]{Mao:Geha:2021, Drlica‑Wagner2019}
+  \citealt{10.1093/mnras/stx3111, 2024ApJ...976..118G}
   ```
 
 - `adstex` works along with your existing bibtex files.
@@ -84,8 +84,6 @@ Once you finish the paper (_sorry, can't help with that!_), simply run `adstex`
 with the following command (_Internet connection is needed for `adstex` to work._):
 
 ```bash
-# Note: if you are using version 0.2.x, please add the -o option. See below.
-
 adstex your_tex_source.tex
 ```
 
@@ -112,11 +110,42 @@ source that you specified in your tex source file.
   If you don't see the paper you are looking for, you can
   directly enter an ADS bibcode or arXiv ID when prompted.
 
-- You can also find a complete option list by running:
-  ```bash
-  adstex --help
-  ```
-  However, you may find the following FAQs more informative.
+
+### Optional arguments
+
+Here are some useful optional arguments that you can specify.
+You can also find a complete option list by running:
+```bash
+adstex --help
+```
+
+- `--use-coauthors` (new in v0.6.0): Use coauthors in the citation key in the ADS search.
+   The citation keys should have the format of `firstauthor:coauthor1:coauthor2:year`.
+
+- `--include-physics`: Include the physics database when searching `author:year` on ADS.
+  Without this option, only the astronomy database is used.
+
+- `--parallel`: Enable multiple threads to speed up the ADS search.
+
+- `--no-update`: Ignore all keys that are already in the bib file.
+  This option will speed up the search, but will not update any arXiv papers that are published in journals.
+
+- `--no-backup`: Do not generate the backup bib file when running `adstex`.
+
+If you want to set any of these optional features as the default behavior,
+you can set the `ADSTEX_ARGS` environment variable in your `~/.bashrc` or `~/.cshrc` file.
+Here's an example:
+
+```bash
+# If you use bash or bash-like shells --
+export ADSTEX_ARGS="--use-coauthors --include-physics --parallel"
+```
+```csh
+# If you use csh or csh-like shells --
+setenv ADSTEX_ARGS "--use-coauthors --include-physics --parallel"
+```
+
+When running `adstex`, you can add `--ignore-env-args` to ignore everything set in `ADSTEX_ARGS`.
 
 
 ## FAQs
@@ -126,8 +155,10 @@ source that you specified in your tex source file.
    Not always; `adstex` uses [regular expression](https://en.wikipedia.org/wiki/Regular_expression), not AI.
 
    For citation keys with multiple authors, if you use a separator to separate
-   the surnames, (e.g., `\cite{Press:Schechter:1974}`), the `adstex` will be able to
+   the surnames, (e.g., `\cite{Press:Schechter:1974}`), `adstex` will be able to
    identify the first author and year to conduct a search on the ADS.
+   If you want `adstex` to also use the coauthor in the citation key (in this example, Schechter),
+   please add the `--use-coauthors` argument when running `adstex`.
 
    For compound surnames, your best bets are
    joining the words without the spaces (e.g., `\cite{deSitter:1913}`), and

--- a/adstex.py
+++ b/adstex.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     from urllib import unquote
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"
 
 _this_year = date.today().year % 100
 _this_cent = date.today().year // 100

--- a/adstex.py
+++ b/adstex.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 
 import os
 import re
+import sys
 import warnings
 from argparse import ArgumentParser
 from builtins import input
@@ -61,21 +62,22 @@ _name_prefix = (
 _name_prefix = sorted(_name_prefix, key=len, reverse=True)
 
 # global configs
-_database = "astronomy"
-_disable_ssl_verification = False
+_DATABASE = "astronomy"
+_DISABLE_SSL = False
+_USE_COAUTHORS = False
 
 
 def fixedAdsSearchQuery(*args, **kwargs):
     q = ads.SearchQuery(*args, **kwargs)
     q.session.headers.pop("Content-Type", None)
-    if _disable_ssl_verification:
+    if _DISABLE_SSL:
         q.session.verify = False
     return q
 
 
 def fixedAdsExportQuery(*args, **kwargs):
     q = ads.ExportQuery(*args, **kwargs)
-    if _disable_ssl_verification:
+    if _DISABLE_SSL:
         q.session.verify = False
     return q
 
@@ -101,12 +103,12 @@ def _y2toy4(y2):
     k = int(y2 > _this_year)
     return str((_this_cent - k) * 100 + y2)
 
-def _fa_split(fa):
-    fa = fa.strip(':')
-    fa = fa.split(':')
-    if len(fa) == 1:
-        return fa[0], []
-    return fa[0], fa[1:]
+
+def _split_authors(fa):
+    fa = fa.strip(':').split(':')
+    if _USE_COAUTHORS and len(fa) > 1:
+        return fa[0], fa[1:]
+    return fa[0], None
 
 
 def _is_like_string(s):
@@ -182,9 +184,9 @@ def id2bibcode(id_this, possible_id_types=("bibcode", "doi", "arxiv")):
                 pass
 
 
-def authoryear2bibcode(author, year, key, coauthors=[]):
-    coauthors = ' '.join([f'author:"{_a}"' for _a in coauthors])
-    q = 'first_author:"{}" {} year:{} database:{}'.format(author, coauthors, year, _database)
+def authoryear2bibcode(author, year, key, coauthors=None):
+    coauthors = ' '.join([f'author:"{_a}"' for _a in coauthors]) if coauthors else ""
+    q = 'first_author:"{}" {} year:{} database:{}'.format(author, coauthors, year, _DATABASE)
     entries = list(
         fixedAdsSearchQuery(
             q=q,
@@ -240,7 +242,7 @@ def find_bibcode_interactive(key):
     m = _re_fayear.match(key)
     if m:
         fa, y = m.groups()
-        fa, ca = _fa_split(fa)
+        fa, ca = _split_authors(fa)
         if len(y) == 2:
             y = _y2toy4(y)
         bibcode = authoryear2bibcode(fa, y, key, coauthors=ca)
@@ -341,6 +343,11 @@ def main():
         help="disable SSL verification (it will render your API key vulnerable)",
     )
     parser.add_argument(
+        "--use-coauthors",
+        action="store_true",
+        help="include coauthors (in the format of 'fa:ca1:ca2:year') in ADS search",
+    )  # thanks to birnstiel for making this suggestion
+    parser.add_argument(
         "--parallel",
         "-P",
         "-p",
@@ -354,25 +361,38 @@ def main():
         help="specify the number of threads used when --parallel is set (default: 8)",
     )  # thanks to dwijn for adding this option
     parser.add_argument(
+        "--ignore-env-args",
+        action="store_true",
+        help="ignore the arguments set in ADSTEX_ARGS environment variable",
+    )  # thanks to birnstiel for making this suggestion
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s {version}".format(version=__version__),
     )
     args = parser.parse_args()
 
+    env_args = os.getenv("ADSTEX_ARGS")
+    if env_args and not args.ignore_env_args:
+        args = parser.parse_args(sys.argv[1:] + env_args.strip().split())
+
     if args.include_physics:
-        global _database
-        _database = '("astronomy" OR "physics")'
+        global _DATABASE
+        _DATABASE = '("astronomy" OR "physics")'
 
     if args.disable_ssl_verification:
         ans = input("You have chosen to disable SSL verification. This will render your API key vulnerable. Do you want to continue? [y/N] ")
         if ans in ("y", "Y", "yes", "Yes", "YES"):
-            global _disable_ssl_verification
-            _disable_ssl_verification = True
+            global _DISABLE_SSL
+            _DISABLE_SSL = True
             warnings.filterwarnings("ignore", "Unverified HTTPS request is being made", Warning)
         else:
             print("OK, abort!")
             return
+
+    if args.use_coauthors:
+        global _USE_COAUTHORS
+        _USE_COAUTHORS = True
 
     if len(args.files) == 1 and args.files[0].lower().endswith(".bib"):  # bib update mode
         if args.output or args.other:

--- a/test.tex
+++ b/test.tex
@@ -1,1 +1,0 @@
-\citep{Mao:Kovacs:2018}

--- a/test.tex
+++ b/test.tex
@@ -1,0 +1,1 @@
+\citep{Mao:Kovacs:2018}


### PR DESCRIPTION
The v0.6.0 version incorporates #49 implemented by @birnstiel , enabling coauthors in the ADS search if the citation key has the format of  `firstauthor:coauthor1:coauthor2:year`. 

However, to avoid breaking backward compatibility, this feature is disabled by default and need to be enabled with the argument `--use-coauthors`. 

To reduce the hassle of specifying `--use-coauthors` every time, this version also introduce a new feature to set an environment variable `ADSTEX_ARGS` for default arguments. For example, setting the following in `.bashrc` will always enable the coauthor and parallel features.
```bash
export ADSTEX_ARGS="--use-coauthors --parallel"
```